### PR TITLE
Synonym fix

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">PyQuiz App</string>
     <string name="Title">Python Quiz App</string>
-    <string name="ctg_syn">Synonym</string>
+    <string name="ctg_syn">Syntax</string>
     <string name="ctg_str">String</string>
     <string name="ctg_boo">Boolean</string>
     <string name="ctg_lis">List</string>


### PR DESCRIPTION
Replaced the "synonym" string value with "syntax". The button now says the correct category.